### PR TITLE
Created initial quote section types

### DIFF
--- a/src/api/landing-page/content-types/landing-page/schema.json
+++ b/src/api/landing-page/content-types/landing-page/schema.json
@@ -38,6 +38,12 @@
       "type": "component",
       "repeatable": false,
       "component": "landing-page.payment-section"
+    },
+    "quoteSection": {
+      "displayName": "Quote Section",
+      "type": "component",
+      "repeatable": false,
+      "component": "landing-page.quote-section"
     }
   }
 }

--- a/src/components/landing-page/quote-carousel-item.json
+++ b/src/components/landing-page/quote-carousel-item.json
@@ -1,0 +1,21 @@
+{
+  "collectionName": "components_landing_page_quote_carousel_items",
+  "info": {
+    "displayName": "Quote Carousel Item"
+  },
+  "options": {},
+  "attributes": {
+    "quoteText": {
+      "type": "text",
+      "required": true
+    },
+    "quoteAuthor": {
+      "type": "string",
+      "required": true
+    },
+    "quoteAuthorRole": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/src/components/landing-page/quote-section.json
+++ b/src/components/landing-page/quote-section.json
@@ -1,0 +1,31 @@
+{
+  "collectionName": "components_landing_page_quote_sections",
+  "info": {
+    "displayName": "Quote Section"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "quoteCarousel": {
+      "displayName": "Quote Carousel Item",
+      "type": "component",
+      "repeatable": true,
+      "component": "landing-page.quote-carousel-item",
+      "required": true
+    },
+    "quoteIcon": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    }
+  }
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -67,6 +67,35 @@ export interface LandingPagePaymentSection extends Schema.Component {
   };
 }
 
+export interface LandingPageQuoteCarouselItem extends Schema.Component {
+  collectionName: 'components_landing_page_quote_carousel_items';
+  info: {
+    displayName: 'Quote Carousel Item';
+  };
+  attributes: {
+    quoteText: Attribute.Text & Attribute.Required;
+    quoteAuthor: Attribute.String & Attribute.Required;
+    quoteAuthorRole: Attribute.String & Attribute.Required;
+  };
+}
+
+export interface LandingPageQuoteSection extends Schema.Component {
+  collectionName: 'components_landing_page_quote_sections';
+  info: {
+    displayName: 'Quote Section';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    quoteCarousel: Attribute.Component<
+      'landing-page.quote-carousel-item',
+      true
+    > &
+      Attribute.Required;
+    quoteIcon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+  };
+}
+
 export interface LandingPageSpecialityCarouselItem extends Schema.Component {
   collectionName: 'components_landing_page_speciality_carousel_items';
   info: {
@@ -177,6 +206,8 @@ declare module '@strapi/types' {
       'footer.social-media-links': FooterSocialMediaLinks;
       'landing-page.initial-image': LandingPageInitialImage;
       'landing-page.payment-section': LandingPagePaymentSection;
+      'landing-page.quote-carousel-item': LandingPageQuoteCarouselItem;
+      'landing-page.quote-section': LandingPageQuoteSection;
       'landing-page.speciality-carousel-item': LandingPageSpecialityCarouselItem;
       'landing-page.specialty-carousel-section': LandingPageSpecialtyCarouselSection;
       'landing-page.video-section': LandingPageVideoSection;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -844,6 +844,7 @@ export interface ApiLandingPageLandingPage extends Schema.SingleType {
     landingImageMobile: Attribute.Component<'landing-page.initial-image'>;
     specialitySection: Attribute.Component<'landing-page.specialty-carousel-section'>;
     paymentSection: Attribute.Component<'landing-page.payment-section'>;
+    quoteSection: Attribute.Component<'landing-page.quote-section'>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
#### Context

- In order to make the frontend quote section the CMS types need to be created so the frontend can fetch the appropriate content and display it

#### Changes proposed in this PR

- Create Quote section types
