### PR TITLE
Create team page types

### DIFF
--- a/src/api/our-team-page/content-types/our-team-page/schema.json
+++ b/src/api/our-team-page/content-types/our-team-page/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "our-team-page",
     "pluralName": "our-team-pages",
-    "displayName": "Our Team Page"
+    "displayName": "Our Team Page",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true

--- a/src/api/our-team-page/content-types/our-team-page/schema.json
+++ b/src/api/our-team-page/content-types/our-team-page/schema.json
@@ -1,0 +1,30 @@
+{
+  "kind": "singleType",
+  "collectionName": "our_team_pages",
+  "info": {
+    "singularName": "our-team-page",
+    "pluralName": "our-team-pages",
+    "displayName": "Our Team Page"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "pageTitle": {
+      "type": "string",
+      "required": true
+    },
+    "pageSubTitle": {
+      "type": "string",
+      "required": true
+    },
+    "departmentSections": {
+      "displayName": "Department Section",
+      "type": "component",
+      "repeatable": true,
+      "component": "our-team-page.department-section",
+      "required": true
+    }
+  }
+}

--- a/src/api/our-team-page/controllers/our-team-page.ts
+++ b/src/api/our-team-page/controllers/our-team-page.ts
@@ -1,0 +1,7 @@
+/**
+ * our-team-page controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::our-team-page.our-team-page');

--- a/src/api/our-team-page/routes/our-team-page.ts
+++ b/src/api/our-team-page/routes/our-team-page.ts
@@ -1,0 +1,7 @@
+/**
+ * our-team-page router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::our-team-page.our-team-page');

--- a/src/api/our-team-page/services/our-team-page.ts
+++ b/src/api/our-team-page/services/our-team-page.ts
@@ -1,0 +1,7 @@
+/**
+ * our-team-page service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::our-team-page.our-team-page');

--- a/src/components/our-team-page/department-section.json
+++ b/src/components/our-team-page/department-section.json
@@ -1,0 +1,20 @@
+{
+  "collectionName": "components_our_team_page_department_sections",
+  "info": {
+    "displayName": "Department Section"
+  },
+  "options": {},
+  "attributes": {
+    "departmentSectionTitle": {
+      "type": "string",
+      "required": true
+    },
+    "teamProfileDetails": {
+      "displayName": "Team Profile Details",
+      "type": "component",
+      "repeatable": true,
+      "component": "our-team-page.team-profile-details",
+      "required": true
+    }
+  }
+}

--- a/src/components/our-team-page/department-section.json
+++ b/src/components/our-team-page/department-section.json
@@ -1,11 +1,12 @@
 {
   "collectionName": "components_our_team_page_department_sections",
   "info": {
-    "displayName": "Department Section"
+    "displayName": "Department Section",
+    "description": ""
   },
   "options": {},
   "attributes": {
-    "departmentSectionTitle": {
+    "title": {
       "type": "string",
       "required": true
     },

--- a/src/components/our-team-page/team-profile-details.json
+++ b/src/components/our-team-page/team-profile-details.json
@@ -1,0 +1,28 @@
+{
+  "collectionName": "components_our_team_page_team_profile_details",
+  "info": {
+    "displayName": "Team Profile Details"
+  },
+  "options": {},
+  "attributes": {
+    "profileImage": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    },
+    "profileName": {
+      "type": "string",
+      "required": true
+    },
+    "profileDescription": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -221,6 +221,34 @@ export interface NavigationBarDropDownLinks extends Schema.Component {
   };
 }
 
+export interface OurTeamPageDepartmentSection extends Schema.Component {
+  collectionName: 'components_our_team_page_department_sections';
+  info: {
+    displayName: 'Department Section';
+  };
+  attributes: {
+    departmentSectionTitle: Attribute.String & Attribute.Required;
+    teamProfileDetails: Attribute.Component<
+      'our-team-page.team-profile-details',
+      true
+    > &
+      Attribute.Required;
+  };
+}
+
+export interface OurTeamPageTeamProfileDetails extends Schema.Component {
+  collectionName: 'components_our_team_page_team_profile_details';
+  info: {
+    displayName: 'Team Profile Details';
+  };
+  attributes: {
+    profileImage: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+    profileName: Attribute.String & Attribute.Required;
+    profileDescription: Attribute.String & Attribute.Required;
+  };
+}
+
 export interface UtilityIconLink extends Schema.Component {
   collectionName: 'components_utility_icon_links';
   info: {
@@ -276,6 +304,8 @@ declare module '@strapi/types' {
       'mission-vision-values-page.values-entries': MissionVisionValuesPageValuesEntries;
       'navigation-bar.button': NavigationBarButton;
       'navigation-bar.drop-down-links': NavigationBarDropDownLinks;
+      'our-team-page.department-section': OurTeamPageDepartmentSection;
+      'our-team-page.team-profile-details': OurTeamPageTeamProfileDetails;
       'utility.icon-link': UtilityIconLink;
       'utility.payment-option': UtilityPaymentOption;
       'utility.standard-link': UtilityStandardLink;

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -225,9 +225,10 @@ export interface OurTeamPageDepartmentSection extends Schema.Component {
   collectionName: 'components_our_team_page_department_sections';
   info: {
     displayName: 'Department Section';
+    description: '';
   };
   attributes: {
-    departmentSectionTitle: Attribute.String & Attribute.Required;
+    title: Attribute.String & Attribute.Required;
     teamProfileDetails: Attribute.Component<
       'our-team-page.team-profile-details',
       true

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -936,6 +936,42 @@ export interface ApiNavigationBarNavigationBar extends Schema.SingleType {
   };
 }
 
+export interface ApiOurTeamPageOurTeamPage extends Schema.SingleType {
+  collectionName: 'our_team_pages';
+  info: {
+    singularName: 'our-team-page';
+    pluralName: 'our-team-pages';
+    displayName: 'Our Team Page';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    pageTitle: Attribute.String & Attribute.Required;
+    pageSubTitle: Attribute.String & Attribute.Required;
+    departmentSections: Attribute.Component<
+      'our-team-page.department-section',
+      true
+    > &
+      Attribute.Required;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::our-team-page.our-team-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::our-team-page.our-team-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 declare module '@strapi/types' {
   export module Shared {
     export interface ContentTypes {
@@ -958,6 +994,7 @@ declare module '@strapi/types' {
       'api::landing-page.landing-page': ApiLandingPageLandingPage;
       'api::mission-vision-and-values-page.mission-vision-and-values-page': ApiMissionVisionAndValuesPageMissionVisionAndValuesPage;
       'api::navigation-bar.navigation-bar': ApiNavigationBarNavigationBar;
+      'api::our-team-page.our-team-page': ApiOurTeamPageOurTeamPage;
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -942,6 +942,7 @@ export interface ApiOurTeamPageOurTeamPage extends Schema.SingleType {
     singularName: 'our-team-page';
     pluralName: 'our-team-pages';
     displayName: 'Our Team Page';
+    description: '';
   };
   options: {
     draftAndPublish: true;


### PR DESCRIPTION
#### Context

- In order to make the new our team page the CMS types need to be created so the frontend can fetch the appropriate content and display it

#### Changes proposed in this PR

- Create our team page types
