### PR TITLE
Create about us page types

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "strapi build",
     "deploy": "strapi deploy",
-    "develop": "strapi develop",
+    "dev": "strapi develop",
     "start": "strapi start",
     "strapi": "strapi"
   },

--- a/src/api/about-us-page/content-types/about-us-page/schema.json
+++ b/src/api/about-us-page/content-types/about-us-page/schema.json
@@ -4,7 +4,8 @@
   "info": {
     "singularName": "about-us-page",
     "pluralName": "about-us-pages",
-    "displayName": "About Us Page"
+    "displayName": "About Us Page",
+    "description": ""
   },
   "options": {
     "draftAndPublish": true
@@ -23,6 +24,13 @@
       "type": "component",
       "repeatable": true,
       "component": "about-us-page.section",
+      "required": true
+    },
+    "imageButtonSection": {
+      "displayName": "imageButtonSection",
+      "type": "component",
+      "repeatable": false,
+      "component": "about-us-page.image-button-section",
       "required": true
     }
   }

--- a/src/api/about-us-page/content-types/about-us-page/schema.json
+++ b/src/api/about-us-page/content-types/about-us-page/schema.json
@@ -1,0 +1,29 @@
+{
+  "kind": "singleType",
+  "collectionName": "about_us_pages",
+  "info": {
+    "singularName": "about-us-page",
+    "pluralName": "about-us-pages",
+    "displayName": "About Us Page"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "landingImage": {
+      "displayName": "landingImage",
+      "type": "component",
+      "repeatable": false,
+      "component": "about-us-page.landing-image",
+      "required": true
+    },
+    "sections": {
+      "displayName": "Section",
+      "type": "component",
+      "repeatable": true,
+      "component": "about-us-page.section",
+      "required": true
+    }
+  }
+}

--- a/src/api/about-us-page/controllers/about-us-page.ts
+++ b/src/api/about-us-page/controllers/about-us-page.ts
@@ -1,0 +1,7 @@
+/**
+ * about-us-page controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::about-us-page.about-us-page');

--- a/src/api/about-us-page/routes/about-us-page.ts
+++ b/src/api/about-us-page/routes/about-us-page.ts
@@ -1,0 +1,7 @@
+/**
+ * about-us-page router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::about-us-page.about-us-page');

--- a/src/api/about-us-page/services/about-us-page.ts
+++ b/src/api/about-us-page/services/about-us-page.ts
@@ -1,0 +1,7 @@
+/**
+ * about-us-page service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::about-us-page.about-us-page');

--- a/src/components/about-us-page/image-button-section.json
+++ b/src/components/about-us-page/image-button-section.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_about_us_page_image_button_sections",
+  "info": {
+    "displayName": "imageButtonSection"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "imageButtons": {
+      "displayName": "ImageButton",
+      "type": "component",
+      "repeatable": true,
+      "component": "about-us-page.image-button"
+    }
+  }
+}

--- a/src/components/about-us-page/image-button.json
+++ b/src/components/about-us-page/image-button.json
@@ -1,0 +1,33 @@
+{
+  "collectionName": "components_about_us_page_image_buttons",
+  "info": {
+    "displayName": "ImageButton",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    },
+    "text": {
+      "type": "string",
+      "required": true
+    },
+    "subText": {
+      "type": "string",
+      "required": true
+    },
+    "linkSlug": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/src/components/about-us-page/landing-image.json
+++ b/src/components/about-us-page/landing-image.json
@@ -1,0 +1,24 @@
+{
+  "collectionName": "components_about_us_page_landing_images",
+  "info": {
+    "displayName": "landingImage"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "image": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    }
+  }
+}

--- a/src/components/about-us-page/section.json
+++ b/src/components/about-us-page/section.json
@@ -1,0 +1,45 @@
+{
+  "collectionName": "components_about_us_page_sections",
+  "info": {
+    "displayName": "Section",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text",
+      "required": true
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    },
+    "link": {
+      "type": "component",
+      "repeatable": false,
+      "component": "utility.standard-link",
+      "required": true
+    },
+    "linkIcon": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -1,5 +1,33 @@
 import type { Schema, Attribute } from '@strapi/strapi';
 
+export interface AboutUsPageLandingImage extends Schema.Component {
+  collectionName: 'components_about_us_page_landing_images';
+  info: {
+    displayName: 'landingImage';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+  };
+}
+
+export interface AboutUsPageSection extends Schema.Component {
+  collectionName: 'components_about_us_page_sections';
+  info: {
+    displayName: 'Section';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    description: Attribute.Text & Attribute.Required;
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+    link: Attribute.Component<'utility.standard-link'> & Attribute.Required;
+    linkIcon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+  };
+}
+
 export interface FooterContactInformation extends Schema.Component {
   collectionName: 'components_footer_contact_informations';
   info: {
@@ -302,6 +330,8 @@ export interface UtilityStandardLink extends Schema.Component {
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
+      'about-us-page.landing-image': AboutUsPageLandingImage;
+      'about-us-page.section': AboutUsPageSection;
       'footer.contact-information': FooterContactInformation;
       'footer.navigation-links': FooterNavigationLinks;
       'footer.social-media-links': FooterSocialMediaLinks;

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -1,5 +1,31 @@
 import type { Schema, Attribute } from '@strapi/strapi';
 
+export interface AboutUsPageImageButtonSection extends Schema.Component {
+  collectionName: 'components_about_us_page_image_button_sections';
+  info: {
+    displayName: 'imageButtonSection';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    imageButtons: Attribute.Component<'about-us-page.image-button', true>;
+  };
+}
+
+export interface AboutUsPageImageButton extends Schema.Component {
+  collectionName: 'components_about_us_page_image_buttons';
+  info: {
+    displayName: 'ImageButton';
+    description: '';
+  };
+  attributes: {
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+    text: Attribute.String & Attribute.Required;
+    subText: Attribute.String & Attribute.Required;
+    linkSlug: Attribute.String & Attribute.Required;
+  };
+}
+
 export interface AboutUsPageLandingImage extends Schema.Component {
   collectionName: 'components_about_us_page_landing_images';
   info: {
@@ -330,6 +356,8 @@ export interface UtilityStandardLink extends Schema.Component {
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
+      'about-us-page.image-button-section': AboutUsPageImageButtonSection;
+      'about-us-page.image-button': AboutUsPageImageButton;
       'about-us-page.landing-image': AboutUsPageLandingImage;
       'about-us-page.section': AboutUsPageSection;
       'footer.contact-information': FooterContactInformation;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -788,6 +788,39 @@ export interface PluginUsersPermissionsUser extends Schema.CollectionType {
   };
 }
 
+export interface ApiAboutUsPageAboutUsPage extends Schema.SingleType {
+  collectionName: 'about_us_pages';
+  info: {
+    singularName: 'about-us-page';
+    pluralName: 'about-us-pages';
+    displayName: 'About Us Page';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    landingImage: Attribute.Component<'about-us-page.landing-image'> &
+      Attribute.Required;
+    sections: Attribute.Component<'about-us-page.section', true> &
+      Attribute.Required;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::about-us-page.about-us-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::about-us-page.about-us-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface ApiFooterFooter extends Schema.SingleType {
   collectionName: 'footers';
   info: {
@@ -1025,6 +1058,7 @@ declare module '@strapi/types' {
       'plugin::users-permissions.permission': PluginUsersPermissionsPermission;
       'plugin::users-permissions.role': PluginUsersPermissionsRole;
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
+      'api::about-us-page.about-us-page': ApiAboutUsPageAboutUsPage;
       'api::footer.footer': ApiFooterFooter;
       'api::landing-page.landing-page': ApiLandingPageLandingPage;
       'api::mission-vision-and-values-page.mission-vision-and-values-page': ApiMissionVisionAndValuesPageMissionVisionAndValuesPage;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -794,6 +794,7 @@ export interface ApiAboutUsPageAboutUsPage extends Schema.SingleType {
     singularName: 'about-us-page';
     pluralName: 'about-us-pages';
     displayName: 'About Us Page';
+    description: '';
   };
   options: {
     draftAndPublish: true;
@@ -802,6 +803,8 @@ export interface ApiAboutUsPageAboutUsPage extends Schema.SingleType {
     landingImage: Attribute.Component<'about-us-page.landing-image'> &
       Attribute.Required;
     sections: Attribute.Component<'about-us-page.section', true> &
+      Attribute.Required;
+    imageButtonSection: Attribute.Component<'about-us-page.image-button-section'> &
       Attribute.Required;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;


### PR DESCRIPTION
# Context

- In order to make the new about us page the CMS types need to be created so the frontend can fetch the appropriate content and display it

## Changes proposed in this PR

- Create our about us page types
