### PR TITLE
Create get involved page types

### DIFF
--- a/src/api/get-involved-page/content-types/get-involved-page/schema.json
+++ b/src/api/get-involved-page/content-types/get-involved-page/schema.json
@@ -1,0 +1,37 @@
+{
+  "kind": "singleType",
+  "collectionName": "get_involved_pages",
+  "info": {
+    "singularName": "get-involved-page",
+    "pluralName": "get-involved-pages",
+    "displayName": "Get Involved Page",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "landingCard": {
+      "displayName": "Landing Card",
+      "type": "component",
+      "repeatable": false,
+      "component": "get-involved-page.landing-card",
+      "required": true
+    },
+    "sections": {
+      "displayName": "Sections",
+      "type": "component",
+      "repeatable": true,
+      "component": "get-involved-page.sections",
+      "required": true
+    },
+    "paymentSection": {
+      "displayName": "Payment Section",
+      "type": "component",
+      "repeatable": false,
+      "component": "get-involved-page.payment-section",
+      "required": true
+    }
+  }
+}

--- a/src/api/get-involved-page/controllers/get-involved-page.ts
+++ b/src/api/get-involved-page/controllers/get-involved-page.ts
@@ -1,0 +1,7 @@
+/**
+ * get-involved-page controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::get-involved-page.get-involved-page');

--- a/src/api/get-involved-page/routes/get-involved-page.ts
+++ b/src/api/get-involved-page/routes/get-involved-page.ts
@@ -1,0 +1,7 @@
+/**
+ * get-involved-page router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::get-involved-page.get-involved-page');

--- a/src/api/get-involved-page/services/get-involved-page.ts
+++ b/src/api/get-involved-page/services/get-involved-page.ts
@@ -1,0 +1,7 @@
+/**
+ * get-involved-page service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::get-involved-page.get-involved-page');

--- a/src/components/get-involved-page/landing-card.json
+++ b/src/components/get-involved-page/landing-card.json
@@ -1,0 +1,24 @@
+{
+  "collectionName": "components_get_involved_page_landing_cards",
+  "info": {
+    "displayName": "Landing Card"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "image": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    }
+  }
+}

--- a/src/components/get-involved-page/payment-section.json
+++ b/src/components/get-involved-page/payment-section.json
@@ -1,0 +1,33 @@
+{
+  "collectionName": "components_get_involved_page_payment_sections",
+  "info": {
+    "displayName": "Payment Section",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "subTitle": {
+      "type": "string"
+    },
+    "paymentOptions": {
+      "type": "component",
+      "repeatable": true,
+      "component": "utility.payment-option"
+    },
+    "paymentOptionIcon": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    }
+  }
+}

--- a/src/components/get-involved-page/sections.json
+++ b/src/components/get-involved-page/sections.json
@@ -1,0 +1,43 @@
+{
+  "collectionName": "components_get_involved_page_sections",
+  "info": {
+    "displayName": "Sections"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text",
+      "required": true
+    },
+    "image": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    },
+    "link": {
+      "type": "component",
+      "repeatable": false,
+      "component": "utility.standard-link"
+    },
+    "linkIcon": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -91,6 +91,50 @@ export interface FooterSocialMediaLinks extends Schema.Component {
   };
 }
 
+export interface GetInvolvedPageLandingCard extends Schema.Component {
+  collectionName: 'components_get_involved_page_landing_cards';
+  info: {
+    displayName: 'Landing Card';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+  };
+}
+
+export interface GetInvolvedPagePaymentSection extends Schema.Component {
+  collectionName: 'components_get_involved_page_payment_sections';
+  info: {
+    displayName: 'Payment Section';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    subTitle: Attribute.String;
+    paymentOptions: Attribute.Component<'utility.payment-option', true>;
+    paymentOptionIcon: Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios'
+    > &
+      Attribute.Required;
+  };
+}
+
+export interface GetInvolvedPageSections extends Schema.Component {
+  collectionName: 'components_get_involved_page_sections';
+  info: {
+    displayName: 'Sections';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    description: Attribute.Text & Attribute.Required;
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+    link: Attribute.Component<'utility.standard-link'>;
+    linkIcon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+  };
+}
+
 export interface LandingPageInitialImage extends Schema.Component {
   collectionName: 'components_landing_page_initial_images';
   info: {
@@ -428,6 +472,9 @@ declare module '@strapi/types' {
       'footer.contact-information': FooterContactInformation;
       'footer.navigation-links': FooterNavigationLinks;
       'footer.social-media-links': FooterSocialMediaLinks;
+      'get-involved-page.landing-card': GetInvolvedPageLandingCard;
+      'get-involved-page.payment-section': GetInvolvedPagePaymentSection;
+      'get-involved-page.sections': GetInvolvedPageSections;
       'landing-page.initial-image': LandingPageInitialImage;
       'landing-page.payment-section': LandingPagePaymentSection;
       'landing-page.quote-carousel-item': LandingPageQuoteCarouselItem;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -863,6 +863,42 @@ export interface ApiFooterFooter extends Schema.SingleType {
   };
 }
 
+export interface ApiGetInvolvedPageGetInvolvedPage extends Schema.SingleType {
+  collectionName: 'get_involved_pages';
+  info: {
+    singularName: 'get-involved-page';
+    pluralName: 'get-involved-pages';
+    displayName: 'Get Involved Page';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    landingCard: Attribute.Component<'get-involved-page.landing-card'> &
+      Attribute.Required;
+    sections: Attribute.Component<'get-involved-page.sections', true> &
+      Attribute.Required;
+    paymentSection: Attribute.Component<'get-involved-page.payment-section'> &
+      Attribute.Required;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::get-involved-page.get-involved-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::get-involved-page.get-involved-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface ApiLandingPageLandingPage extends Schema.SingleType {
   collectionName: 'landing_pages';
   info: {
@@ -1100,6 +1136,7 @@ declare module '@strapi/types' {
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
       'api::about-us-page.about-us-page': ApiAboutUsPageAboutUsPage;
       'api::footer.footer': ApiFooterFooter;
+      'api::get-involved-page.get-involved-page': ApiGetInvolvedPageGetInvolvedPage;
       'api::landing-page.landing-page': ApiLandingPageLandingPage;
       'api::mission-vision-and-values-page.mission-vision-and-values-page': ApiMissionVisionAndValuesPageMissionVisionAndValuesPage;
       'api::navigation-bar.navigation-bar': ApiNavigationBarNavigationBar;


### PR DESCRIPTION
# Context

- In order to make the new get involved page the CMS types need to be created so the frontend can fetch the appropriate content and display it

## Changes proposed in this PR

- Create get involved page types
