### PR TITLE
Create donate page types

### DIFF
--- a/src/api/donate-page/content-types/donate-page/schema.json
+++ b/src/api/donate-page/content-types/donate-page/schema.json
@@ -1,0 +1,45 @@
+{
+  "kind": "singleType",
+  "collectionName": "donate_pages",
+  "info": {
+    "singularName": "donate-page",
+    "pluralName": "donate-pages",
+    "displayName": "Donate Page",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "landingCard": {
+      "displayName": "Landing Card",
+      "type": "component",
+      "repeatable": false,
+      "component": "donate-page.landing-card",
+      "required": true
+    },
+    "preMetricText": {
+      "type": "text",
+      "required": true
+    },
+    "metrics": {
+      "displayName": "Metric",
+      "type": "component",
+      "repeatable": true,
+      "component": "donate-page.metric",
+      "required": true
+    },
+    "postMetricText": {
+      "type": "text",
+      "required": true
+    },
+    "paymentSection": {
+      "displayName": "Payment Section",
+      "type": "component",
+      "repeatable": false,
+      "component": "donate-page.payment-section",
+      "required": true
+    }
+  }
+}

--- a/src/api/donate-page/controllers/donate-page.ts
+++ b/src/api/donate-page/controllers/donate-page.ts
@@ -1,0 +1,7 @@
+/**
+ * donate-page controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::donate-page.donate-page');

--- a/src/api/donate-page/routes/donate-page.ts
+++ b/src/api/donate-page/routes/donate-page.ts
@@ -1,0 +1,7 @@
+/**
+ * donate-page router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::donate-page.donate-page');

--- a/src/api/donate-page/services/donate-page.ts
+++ b/src/api/donate-page/services/donate-page.ts
@@ -1,0 +1,7 @@
+/**
+ * donate-page service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::donate-page.donate-page');

--- a/src/components/donate-page/landing-card.json
+++ b/src/components/donate-page/landing-card.json
@@ -1,0 +1,24 @@
+{
+  "collectionName": "components_donate_page_landing_cards",
+  "info": {
+    "displayName": "Landing Card"
+  },
+  "options": {},
+  "attributes": {
+    "image": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    },
+    "title": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/src/components/donate-page/metric.json
+++ b/src/components/donate-page/metric.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_donate_page_metrics",
+  "info": {
+    "displayName": "Metric"
+  },
+  "options": {},
+  "attributes": {
+    "value": {
+      "type": "string",
+      "required": true
+    },
+    "valueDescription": {
+      "type": "text",
+      "required": true
+    }
+  }
+}

--- a/src/components/donate-page/payment-section.json
+++ b/src/components/donate-page/payment-section.json
@@ -1,0 +1,34 @@
+{
+  "collectionName": "components_donate_page_payment_sections",
+  "info": {
+    "displayName": "Payment Section",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "subTitle": {
+      "type": "text",
+      "required": true
+    },
+    "paymentOptions": {
+      "type": "component",
+      "repeatable": true,
+      "component": "utility.payment-option"
+    },
+    "paymentOptionIcon": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    }
+  }
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -54,6 +54,46 @@ export interface AboutUsPageSection extends Schema.Component {
   };
 }
 
+export interface DonatePageLandingCard extends Schema.Component {
+  collectionName: 'components_donate_page_landing_cards';
+  info: {
+    displayName: 'Landing Card';
+  };
+  attributes: {
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+    title: Attribute.String & Attribute.Required;
+  };
+}
+
+export interface DonatePageMetric extends Schema.Component {
+  collectionName: 'components_donate_page_metrics';
+  info: {
+    displayName: 'Metric';
+  };
+  attributes: {
+    value: Attribute.String & Attribute.Required;
+    valueDescription: Attribute.Text & Attribute.Required;
+  };
+}
+
+export interface DonatePagePaymentSection extends Schema.Component {
+  collectionName: 'components_donate_page_payment_sections';
+  info: {
+    displayName: 'Payment Section';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    subTitle: Attribute.Text & Attribute.Required;
+    paymentOptions: Attribute.Component<'utility.payment-option', true>;
+    paymentOptionIcon: Attribute.Media<
+      'images' | 'files' | 'videos' | 'audios'
+    > &
+      Attribute.Required;
+  };
+}
+
 export interface FooterContactInformation extends Schema.Component {
   collectionName: 'components_footer_contact_informations';
   info: {
@@ -469,6 +509,9 @@ declare module '@strapi/types' {
       'about-us-page.image-button': AboutUsPageImageButton;
       'about-us-page.landing-image': AboutUsPageLandingImage;
       'about-us-page.section': AboutUsPageSection;
+      'donate-page.landing-card': DonatePageLandingCard;
+      'donate-page.metric': DonatePageMetric;
+      'donate-page.payment-section': DonatePagePaymentSection;
       'footer.contact-information': FooterContactInformation;
       'footer.navigation-links': FooterNavigationLinks;
       'footer.social-media-links': FooterSocialMediaLinks;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -824,6 +824,44 @@ export interface ApiAboutUsPageAboutUsPage extends Schema.SingleType {
   };
 }
 
+export interface ApiDonatePageDonatePage extends Schema.SingleType {
+  collectionName: 'donate_pages';
+  info: {
+    singularName: 'donate-page';
+    pluralName: 'donate-pages';
+    displayName: 'Donate Page';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    landingCard: Attribute.Component<'donate-page.landing-card'> &
+      Attribute.Required;
+    preMetricText: Attribute.Text & Attribute.Required;
+    metrics: Attribute.Component<'donate-page.metric', true> &
+      Attribute.Required;
+    postMetricText: Attribute.Text & Attribute.Required;
+    paymentSection: Attribute.Component<'donate-page.payment-section'> &
+      Attribute.Required;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::donate-page.donate-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::donate-page.donate-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface ApiFooterFooter extends Schema.SingleType {
   collectionName: 'footers';
   info: {
@@ -1135,6 +1173,7 @@ declare module '@strapi/types' {
       'plugin::users-permissions.role': PluginUsersPermissionsRole;
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
       'api::about-us-page.about-us-page': ApiAboutUsPageAboutUsPage;
+      'api::donate-page.donate-page': ApiDonatePageDonatePage;
       'api::footer.footer': ApiFooterFooter;
       'api::get-involved-page.get-involved-page': ApiGetInvolvedPageGetInvolvedPage;
       'api::landing-page.landing-page': ApiLandingPageLandingPage;


### PR DESCRIPTION
# Context

- In order to make the new donate page the CMS types need to be created so the frontend can fetch the appropriate content and display it

## Changes proposed in this PR

- Create donate page types
