### PR TITLE
Create initial types

### DIFF
--- a/src/api/our-work-sub-page/content-types/our-work-sub-page/schema.json
+++ b/src/api/our-work-sub-page/content-types/our-work-sub-page/schema.json
@@ -1,0 +1,37 @@
+{
+  "kind": "collectionType",
+  "collectionName": "our_work_sub_pages",
+  "info": {
+    "singularName": "our-work-sub-page",
+    "pluralName": "our-work-sub-pages",
+    "displayName": "Our Work Sub-Page"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "landingImage": {
+      "type": "component",
+      "repeatable": false,
+      "component": "stat-template-page.landing-image",
+      "required": true
+    },
+    "quote": {
+      "type": "component",
+      "repeatable": false,
+      "component": "stat-template-page.quote",
+      "required": true
+    },
+    "metrics": {
+      "type": "component",
+      "repeatable": true,
+      "component": "stat-template-page.metric",
+      "required": true
+    },
+    "freeText": {
+      "type": "text",
+      "required": true
+    }
+  }
+}

--- a/src/api/our-work-sub-page/controllers/our-work-sub-page.ts
+++ b/src/api/our-work-sub-page/controllers/our-work-sub-page.ts
@@ -1,0 +1,7 @@
+/**
+ * our-work-sub-page controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::our-work-sub-page.our-work-sub-page');

--- a/src/api/our-work-sub-page/routes/our-work-sub-page.ts
+++ b/src/api/our-work-sub-page/routes/our-work-sub-page.ts
@@ -1,0 +1,7 @@
+/**
+ * our-work-sub-page router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::our-work-sub-page.our-work-sub-page');

--- a/src/api/our-work-sub-page/services/our-work-sub-page.ts
+++ b/src/api/our-work-sub-page/services/our-work-sub-page.ts
@@ -1,0 +1,7 @@
+/**
+ * our-work-sub-page service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::our-work-sub-page.our-work-sub-page');

--- a/src/components/stat-template-page/landing-image.json
+++ b/src/components/stat-template-page/landing-image.json
@@ -1,0 +1,24 @@
+{
+  "collectionName": "components_stat_template_page_landing_images",
+  "info": {
+    "displayName": "Landing Image"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "image": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    }
+  }
+}

--- a/src/components/stat-template-page/metric.json
+++ b/src/components/stat-template-page/metric.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_stat_template_page_metrics",
+  "info": {
+    "displayName": "Metric"
+  },
+  "options": {},
+  "attributes": {
+    "value": {
+      "type": "string",
+      "required": true
+    },
+    "valueDescription": {
+      "type": "text",
+      "required": true
+    }
+  }
+}

--- a/src/components/stat-template-page/quote.json
+++ b/src/components/stat-template-page/quote.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_stat_template_page_quotes",
+  "info": {
+    "displayName": "Quote"
+  },
+  "options": {},
+  "attributes": {
+    "author": {
+      "type": "string",
+      "required": true
+    },
+    "body": {
+      "type": "text",
+      "required": true
+    }
+  }
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -466,6 +466,40 @@ export interface OurWorkPageQuote extends Schema.Component {
   };
 }
 
+export interface StatTemplatePageLandingImage extends Schema.Component {
+  collectionName: 'components_stat_template_page_landing_images';
+  info: {
+    displayName: 'Landing Image';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+  };
+}
+
+export interface StatTemplatePageMetric extends Schema.Component {
+  collectionName: 'components_stat_template_page_metrics';
+  info: {
+    displayName: 'Metric';
+  };
+  attributes: {
+    value: Attribute.String & Attribute.Required;
+    valueDescription: Attribute.Text & Attribute.Required;
+  };
+}
+
+export interface StatTemplatePageQuote extends Schema.Component {
+  collectionName: 'components_stat_template_page_quotes';
+  info: {
+    displayName: 'Quote';
+  };
+  attributes: {
+    author: Attribute.String & Attribute.Required;
+    body: Attribute.Text & Attribute.Required;
+  };
+}
+
 export interface UtilityIconLink extends Schema.Component {
   collectionName: 'components_utility_icon_links';
   info: {
@@ -539,6 +573,9 @@ declare module '@strapi/types' {
       'our-work-page.landing-image': OurWorkPageLandingImage;
       'our-work-page.metric': OurWorkPageMetric;
       'our-work-page.quote': OurWorkPageQuote;
+      'stat-template-page.landing-image': StatTemplatePageLandingImage;
+      'stat-template-page.metric': StatTemplatePageMetric;
+      'stat-template-page.quote': StatTemplatePageQuote;
       'utility.icon-link': UtilityIconLink;
       'utility.payment-option': UtilityPaymentOption;
       'utility.standard-link': UtilityStandardLink;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1154,6 +1154,41 @@ export interface ApiOurWorkPageOurWorkPage extends Schema.SingleType {
   };
 }
 
+export interface ApiOurWorkSubPageOurWorkSubPage extends Schema.CollectionType {
+  collectionName: 'our_work_sub_pages';
+  info: {
+    singularName: 'our-work-sub-page';
+    pluralName: 'our-work-sub-pages';
+    displayName: 'Our Work Sub-Page';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    landingImage: Attribute.Component<'stat-template-page.landing-image'> &
+      Attribute.Required;
+    quote: Attribute.Component<'stat-template-page.quote'> & Attribute.Required;
+    metrics: Attribute.Component<'stat-template-page.metric', true> &
+      Attribute.Required;
+    freeText: Attribute.Text & Attribute.Required;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::our-work-sub-page.our-work-sub-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::our-work-sub-page.our-work-sub-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 declare module '@strapi/types' {
   export module Shared {
     export interface ContentTypes {
@@ -1182,6 +1217,7 @@ declare module '@strapi/types' {
       'api::our-donors-page.our-donors-page': ApiOurDonorsPageOurDonorsPage;
       'api::our-team-page.our-team-page': ApiOurTeamPageOurTeamPage;
       'api::our-work-page.our-work-page': ApiOurWorkPageOurWorkPage;
+      'api::our-work-sub-page.our-work-sub-page': ApiOurWorkSubPageOurWorkSubPage;
     }
   }
 }


### PR DESCRIPTION
# Context

- In order to make the new stat template page the CMS types need to be created so the frontend can fetch the appropriate content and display it

## Changes proposed in this PR

- Create stat template page types
