### PR TITLE
Hacky implementation of blog post for our story page

### DIFF
--- a/src/api/our-story-page/content-types/our-story-page/schema.json
+++ b/src/api/our-story-page/content-types/our-story-page/schema.json
@@ -1,0 +1,43 @@
+{
+  "kind": "singleType",
+  "collectionName": "our_story_pages",
+  "info": {
+    "singularName": "our-story-page",
+    "pluralName": "our-story-pages",
+    "displayName": "Our Story Page",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "blogPostBody": {
+      "type": "richtext",
+      "required": true
+    },
+    "blogPostSummary": {
+      "type": "text",
+      "required": true
+    },
+    "landingImage": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    },
+    "author": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/src/api/our-story-page/controllers/our-story-page.ts
+++ b/src/api/our-story-page/controllers/our-story-page.ts
@@ -1,0 +1,7 @@
+/**
+ * our-story-page controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::our-story-page.our-story-page');

--- a/src/api/our-story-page/routes/our-story-page.ts
+++ b/src/api/our-story-page/routes/our-story-page.ts
@@ -1,0 +1,7 @@
+/**
+ * our-story-page router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::our-story-page.our-story-page');

--- a/src/api/our-story-page/services/our-story-page.ts
+++ b/src/api/our-story-page/services/our-story-page.ts
@@ -1,0 +1,7 @@
+/**
+ * our-story-page service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::our-story-page.our-story-page');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1187,6 +1187,42 @@ export interface ApiOurDonorsPageOurDonorsPage extends Schema.SingleType {
   };
 }
 
+export interface ApiOurStoryPageOurStoryPage extends Schema.SingleType {
+  collectionName: 'our_story_pages';
+  info: {
+    singularName: 'our-story-page';
+    pluralName: 'our-story-pages';
+    displayName: 'Our Story Page';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    blogPostBody: Attribute.RichText & Attribute.Required;
+    blogPostSummary: Attribute.Text & Attribute.Required;
+    landingImage: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+    author: Attribute.String & Attribute.Required;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::our-story-page.our-story-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::our-story-page.our-story-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface ApiOurTeamPageOurTeamPage extends Schema.SingleType {
   collectionName: 'our_team_pages';
   info: {
@@ -1327,6 +1363,7 @@ declare module '@strapi/types' {
       'api::mission-vision-and-values-page.mission-vision-and-values-page': ApiMissionVisionAndValuesPageMissionVisionAndValuesPage;
       'api::navigation-bar.navigation-bar': ApiNavigationBarNavigationBar;
       'api::our-donors-page.our-donors-page': ApiOurDonorsPageOurDonorsPage;
+      'api::our-story-page.our-story-page': ApiOurStoryPageOurStoryPage;
       'api::our-team-page.our-team-page': ApiOurTeamPageOurTeamPage;
       'api::our-work-page.our-work-page': ApiOurWorkPageOurWorkPage;
       'api::our-work-sub-page.our-work-sub-page': ApiOurWorkSubPageOurWorkSubPage;


### PR DESCRIPTION
#### Context

- We want to push for a DR go live. As a result we're cutting a few corners. The our story page is just a light version of the blog page so for now matching the naming conventions to the blog post style will enable us to use the frontend template. In the future we should create the blog page as a template in Strapi with a different name for these use cases.

#### Changes proposed in this PR

- Create our story single type
