### PR TITLE
hackily implement philantropy page using blog template

### DIFF
--- a/src/api/philanthropy-page/content-types/philanthropy-page/schema.json
+++ b/src/api/philanthropy-page/content-types/philanthropy-page/schema.json
@@ -1,0 +1,42 @@
+{
+  "kind": "singleType",
+  "collectionName": "philanthropy_pages",
+  "info": {
+    "singularName": "philanthropy-page",
+    "pluralName": "philanthropy-pages",
+    "displayName": "Philanthropy Page"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "blogPostBody": {
+      "type": "richtext",
+      "required": true
+    },
+    "blogPostSummary": {
+      "type": "text",
+      "required": true
+    },
+    "landingImage": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    },
+    "author": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/src/api/philanthropy-page/controllers/philanthropy-page.ts
+++ b/src/api/philanthropy-page/controllers/philanthropy-page.ts
@@ -1,0 +1,7 @@
+/**
+ * philanthropy-page controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::philanthropy-page.philanthropy-page');

--- a/src/api/philanthropy-page/routes/philanthropy-page.ts
+++ b/src/api/philanthropy-page/routes/philanthropy-page.ts
@@ -1,0 +1,7 @@
+/**
+ * philanthropy-page router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::philanthropy-page.philanthropy-page');

--- a/src/api/philanthropy-page/services/philanthropy-page.ts
+++ b/src/api/philanthropy-page/services/philanthropy-page.ts
@@ -1,0 +1,7 @@
+/**
+ * philanthropy-page service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::philanthropy-page.philanthropy-page');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1334,6 +1334,41 @@ export interface ApiOurWorkSubPageOurWorkSubPage extends Schema.CollectionType {
   };
 }
 
+export interface ApiPhilanthropyPagePhilanthropyPage extends Schema.SingleType {
+  collectionName: 'philanthropy_pages';
+  info: {
+    singularName: 'philanthropy-page';
+    pluralName: 'philanthropy-pages';
+    displayName: 'Philanthropy Page';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    blogPostBody: Attribute.RichText & Attribute.Required;
+    blogPostSummary: Attribute.Text & Attribute.Required;
+    landingImage: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+    author: Attribute.String & Attribute.Required;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::philanthropy-page.philanthropy-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::philanthropy-page.philanthropy-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 declare module '@strapi/types' {
   export module Shared {
     export interface ContentTypes {
@@ -1367,6 +1402,7 @@ declare module '@strapi/types' {
       'api::our-team-page.our-team-page': ApiOurTeamPageOurTeamPage;
       'api::our-work-page.our-work-page': ApiOurWorkPageOurWorkPage;
       'api::our-work-sub-page.our-work-sub-page': ApiOurWorkSubPageOurWorkSubPage;
+      'api::philanthropy-page.philanthropy-page': ApiPhilanthropyPagePhilanthropyPage;
     }
   }
 }


### PR DESCRIPTION
#### Context

- We want to push for a DR go live. As a result we're cutting a few corners. The our philanthropy page is just a light version of the blog page so for now matching the naming conventions to the blog post style will enable us to use the blog post template. In the future we should create the blog page as a template in Strapi with a different name for these use cases.

#### Changes proposed in this PR

- Create philantropy page types
