### PR TITLE
added fundraising page copying strucuture of get involved

### DIFF
--- a/src/api/fundraising-page/content-types/fundraising-page/schema.json
+++ b/src/api/fundraising-page/content-types/fundraising-page/schema.json
@@ -1,0 +1,33 @@
+{
+  "kind": "singleType",
+  "collectionName": "fundraising_pages",
+  "info": {
+    "singularName": "fundraising-page",
+    "pluralName": "fundraising-pages",
+    "displayName": "Fundraising Page"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "landingCard": {
+      "type": "component",
+      "repeatable": false,
+      "component": "get-involved-page.landing-card",
+      "required": true
+    },
+    "sections": {
+      "type": "component",
+      "repeatable": true,
+      "component": "get-involved-page.sections",
+      "required": true
+    },
+    "paymentSection": {
+      "type": "component",
+      "repeatable": false,
+      "component": "get-involved-page.payment-section",
+      "required": true
+    }
+  }
+}

--- a/src/api/fundraising-page/controllers/fundraising-page.ts
+++ b/src/api/fundraising-page/controllers/fundraising-page.ts
@@ -1,0 +1,7 @@
+/**
+ * fundraising-page controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::fundraising-page.fundraising-page');

--- a/src/api/fundraising-page/routes/fundraising-page.ts
+++ b/src/api/fundraising-page/routes/fundraising-page.ts
@@ -1,0 +1,7 @@
+/**
+ * fundraising-page router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::fundraising-page.fundraising-page');

--- a/src/api/fundraising-page/services/fundraising-page.ts
+++ b/src/api/fundraising-page/services/fundraising-page.ts
@@ -1,0 +1,7 @@
+/**
+ * fundraising-page service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::fundraising-page.fundraising-page');

--- a/src/components/get-involved-page/sections.json
+++ b/src/components/get-involved-page/sections.json
@@ -1,7 +1,8 @@
 {
   "collectionName": "components_get_involved_page_sections",
   "info": {
-    "displayName": "Sections"
+    "displayName": "Sections",
+    "description": ""
   },
   "options": {},
   "attributes": {
@@ -14,15 +15,15 @@
       "required": true
     },
     "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
       "allowedTypes": [
         "images",
         "files",
         "videos",
         "audios"
-      ],
-      "type": "media",
-      "multiple": false,
-      "required": true
+      ]
     },
     "link": {
       "type": "component",
@@ -30,14 +31,15 @@
       "component": "utility.standard-link"
     },
     "linkIcon": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
       "allowedTypes": [
         "images",
         "files",
         "videos",
         "audios"
-      ],
-      "type": "media",
-      "multiple": false
+      ]
     }
   }
 }

--- a/src/components/utility/standard-link.json
+++ b/src/components/utility/standard-link.json
@@ -1,15 +1,18 @@
 {
   "collectionName": "components_utility_standard_links",
   "info": {
-    "displayName": "Standard Link"
+    "displayName": "Standard Link",
+    "description": ""
   },
   "options": {},
   "attributes": {
     "linkString": {
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     "linkSlug": {
-      "type": "string"
+      "type": "string",
+      "required": true
     }
   }
 }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -164,6 +164,7 @@ export interface GetInvolvedPageSections extends Schema.Component {
   collectionName: 'components_get_involved_page_sections';
   info: {
     displayName: 'Sections';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
@@ -171,7 +172,8 @@ export interface GetInvolvedPageSections extends Schema.Component {
     image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
       Attribute.Required;
     link: Attribute.Component<'utility.standard-link'>;
-    linkIcon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    linkIcon: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
   };
 }
 
@@ -507,10 +509,11 @@ export interface UtilityStandardLink extends Schema.Component {
   collectionName: 'components_utility_standard_links';
   info: {
     displayName: 'Standard Link';
+    description: '';
   };
   attributes: {
-    linkString: Attribute.String;
-    linkSlug: Attribute.String;
+    linkString: Attribute.String & Attribute.Required;
+    linkSlug: Attribute.String & Attribute.Required;
   };
 }
 

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -975,6 +975,41 @@ export interface ApiFundraisingEventFundraisingEvent
   };
 }
 
+export interface ApiFundraisingPageFundraisingPage extends Schema.SingleType {
+  collectionName: 'fundraising_pages';
+  info: {
+    singularName: 'fundraising-page';
+    pluralName: 'fundraising-pages';
+    displayName: 'Fundraising Page';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    landingCard: Attribute.Component<'get-involved-page.landing-card'> &
+      Attribute.Required;
+    sections: Attribute.Component<'get-involved-page.sections', true> &
+      Attribute.Required;
+    paymentSection: Attribute.Component<'get-involved-page.payment-section'> &
+      Attribute.Required;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::fundraising-page.fundraising-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::fundraising-page.fundraising-page',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface ApiGetInvolvedPageGetInvolvedPage extends Schema.SingleType {
   collectionName: 'get_involved_pages';
   info: {
@@ -1392,6 +1427,7 @@ declare module '@strapi/types' {
       'api::donate-page.donate-page': ApiDonatePageDonatePage;
       'api::footer.footer': ApiFooterFooter;
       'api::fundraising-event.fundraising-event': ApiFundraisingEventFundraisingEvent;
+      'api::fundraising-page.fundraising-page': ApiFundraisingPageFundraisingPage;
       'api::get-involved-page.get-involved-page': ApiGetInvolvedPageGetInvolvedPage;
       'api::job-post.job-post': ApiJobPostJobPost;
       'api::landing-page.landing-page': ApiLandingPageLandingPage;


### PR DESCRIPTION
#### Context

- Users need a way to easily navigate between the various different fundraising avenues

#### Changes proposed in this PR

- In the same format as the get involved page with the different customizable sections
